### PR TITLE
🩹Fix action

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,15 +22,15 @@ jobs:
       matrix:
         example_name: [
             quick-start,
-            # fluorescence,
-            # # transient-absorption,  # Not working with 0.3.2
-            # spectral-constraints,
-            # # spectral-guidance,  # Not working with 0.3.2
-            # two-datasets,
-            # sim-3d-disp,
-            # sim-3d-nodisp,
-            # sim-3d-weight,
-            # sim-6d-disp,
+            fluorescence,
+            # transient-absorption,  # Not working with 0.3.2
+            spectral-constraints,
+            # spectral-guidance,  # Not working with 0.3.2
+            two-datasets,
+            sim-3d-disp,
+            sim-3d-nodisp,
+            sim-3d-weight,
+            sim-6d-disp,
           ]
     steps:
       - uses: actions/checkout@v2
@@ -43,15 +43,16 @@ jobs:
         with:
           python-version: 3.8
       - name: Install pyglotaran
-        run: pip install .
+        run: |
+          pip install wheel
+          pip install .
       - name: Cloning pyglotaran-examples
         if: ${{ github.event.inputs.pyglotaran_examples_branch }} == ""
         uses: actions/checkout@v2
         with:
           path: pyglotaran-examples
       - id: example-run
-        # uses: glotaran/pyglotaran-examples@main
-        uses: s-weigand/pyglotaran-examples@fix-action
+        uses: glotaran/pyglotaran-examples@main
         with:
           example_name: ${{ matrix.example_name }}
           examples_branch: ${{ github.event.inputs.pyglotaran_examples_branch }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,20 +22,21 @@ jobs:
       matrix:
         example_name: [
             quick-start,
-            fluorescence,
-            # transient-absorption,  # Not working with 0.3.2
-            spectral-constraints,
-            # spectral-guidance,  # Not working with 0.3.2
-            two-datasets,
-            sim-3d-disp,
-            sim-3d-nodisp,
-            sim-3d-weight,
-            sim-6d-disp,
+            # fluorescence,
+            # # transient-absorption,  # Not working with 0.3.2
+            # spectral-constraints,
+            # # spectral-guidance,  # Not working with 0.3.2
+            # two-datasets,
+            # sim-3d-disp,
+            # sim-3d-nodisp,
+            # sim-3d-weight,
+            # sim-6d-disp,
           ]
     steps:
       - uses: actions/checkout@v2
         with:
           repository: "glotaran/pyglotaran"
+          # If not provided (push and pull_request event) it uses the default branch
           ref: ${{ github.event.inputs.pyglotaran_branch }}
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -43,8 +44,14 @@ jobs:
           python-version: 3.8
       - name: Install pyglotaran
         run: pip install .
+      - name: Cloning pyglotaran-examples
+        if: ${{ github.event.inputs.pyglotaran_examples_branch }} == ""
+        uses: actions/checkout@v2
+        with:
+          path: pyglotaran-examples
       - id: example-run
-        uses: glotaran/pyglotaran-examples@main
+        # uses: glotaran/pyglotaran-examples@main
+        uses: s-weigand/pyglotaran-examples@fix-action
         with:
           example_name: ${{ matrix.example_name }}
           examples_branch: ${{ github.event.inputs.pyglotaran_examples_branch }}

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,17 @@ runs:
   steps:
     - name: Clone pyglotaran-examples to pyglotaran-examples
       run: |
-        echo "::group:: Cloning examples branch  to pyglotaran-examples"
-        git clone  --depth 1 -b ${{ inputs.examples_branch }} https://github.com/glotaran/pyglotaran-examples.git
+        [ ! -d pyglotaran-examples ] && [ ! -n '${{ inputs.examples_branch }}' ] && \
+          { \
+            echo "::error:: Branch not provided and 'pyglotaran-examples' folder doesn't exist.\
+            Manually clone the examples repo to 'pyglotaran-examples' if you use it with the 'push' or 'pull_request' event."; \
+            exit 1; \
+          }
+        echo "::group:: Cloning examples branch '${{ inputs.examples_branch }}' to pyglotaran-examples"
+        [ ! -d pyglotaran-examples ] && \
+        # git clone  --depth 1 -b ${{ inputs.examples_branch }} https://github.com/glotaran/pyglotaran-examples.git || \
+          git clone  --depth 1 -b ${{ inputs.examples_branch }} https://github.com/s-weigand/pyglotaran-examples.git || \
+          echo "Folder pyglotaran-examples already exists, skipping cloning."
         echo "::endgroup::"
       shell: bash
     - name: Install pyglotaran-examples

--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,7 @@ runs:
           }
         echo "::group:: Cloning examples branch '${{ inputs.examples_branch }}' to pyglotaran-examples"
         [ ! -d pyglotaran-examples ] && \
-        # git clone  --depth 1 -b ${{ inputs.examples_branch }} https://github.com/glotaran/pyglotaran-examples.git || \
-          git clone  --depth 1 -b ${{ inputs.examples_branch }} https://github.com/s-weigand/pyglotaran-examples.git || \
+          git clone  --depth 1 -b ${{ inputs.examples_branch }} https://github.com/glotaran/pyglotaran-examples.git || \
           echo "Folder pyglotaran-examples already exists, skipping cloning."
         echo "::endgroup::"
       shell: bash

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,7 +1,6 @@
 import functools
 import warnings
 import os
-import logging
 from pathlib import Path
 
 import matplotlib


### PR DESCRIPTION
The action added by #13 did only properly work with `workflow_dispatch` but failed with `push` and `pull_request` events.
The reason for this was that `github.event.inputs.pyglotaran_examples_branch` was only set on `workflow_dispatch` and other events didn't use its default. 
This is why
```
git clone --depth 1 -b ${{ inputs.examples_branch }} https://github.com/glotaran/pyglotaran-examples.git
```
evaluated to
```
git clone --depth 1 -b https://github.com/glotaran/pyglotaran-examples.git
```
and git did throw an error because there wasn't a repo to clone provided.

Now the action checks that either `inputs.examples_branch` is provided or that a folder `pyglotaran-examples` exists.
If none of those conditions are met it raises an error explaining whats needs to be done.

The workflow now clones `pyglotaran-examples` if it is run on `push` or `pull_request`, that way pushes and PRs will use the correct commits instead of cloning code already on `glotaran/pyglotaran-examples`.

The CI will fail on this PR since it uses the action on `main` which still has the bug.
Examples of the 3 different trigger events can be found here:
- [PR](https://github.com/s-weigand/pyglotaran-examples/pull/1)
- [push](https://github.com/s-weigand/pyglotaran-examples/actions/runs/736400754)
- [workflow_dispatch](https://github.com/s-weigand/pyglotaran-examples/actions/runs/736389405)