### PR TITLE
Revert "Bump actions/cache from v2 to v2.1.4"

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
-      - uses: actions/cache@v2.1.4
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-autoupdate


### PR DESCRIPTION
Reverts glotaran/pyglotaran-examples#11
Let's keep it `v2`, since `v2.1.4` has some issues https://github.com/actions/cache/issues/528
`v2` now points at `v2.1.5` which doesn't have known bugs.