### PR TITLE
🩹 Pin the installed version of pyglotaran-extras to use a git sha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pyglotaran>=0.3.0
 jupyterlab>=2.0.0
 matplotlib>=3.3.0
 
-git+https://github.com/glotaran/pyglotaran-extras.git
+git+https://github.com/glotaran/pyglotaran-extras.git@c26346060b0a82cbbdfd9a0c84a2fe2fdd2cd4c4
 
 yaargh>=0.28.0


### PR DESCRIPTION
That way the tagged version is really frozen in time and won't change behavior until we can use the pinned pypi version of pyglotaran-extras.

For the existing v0.3.3 tag we have two option:
1. Delete it and create a new one (it currently isn't used as far as we know anyway)
2. Create a new tag (e.g. with [pythonic naming](https://www.python.org/dev/peps/pep-0440/) `v0.3.3.post1`)

After this PR got merged we should create/update the tag and then we can revert it again.