### PR TITLE
Revert "🩹 Pin the installed version of pyglotaran-extras to use a git sha"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pyglotaran>=0.3.0
 jupyterlab>=2.0.0
 matplotlib>=3.3.0
 
-git+https://github.com/glotaran/pyglotaran-extras.git@c26346060b0a82cbbdfd9a0c84a2fe2fdd2cd4c4
+git+https://github.com/glotaran/pyglotaran-extras.git
 
 yaargh>=0.28.0


### PR DESCRIPTION
Reverts glotaran/pyglotaran-examples#29

After recreating the tag we can unpin `pyglotaran-extras` again.