### PR TITLE
🧪 Fix number of 'maximum_number_function_evaluations'

### DIFF
--- a/.github/workflows/update_compare_results.yml
+++ b/.github/workflows/update_compare_results.yml
@@ -1,0 +1,104 @@
+name: "Update comparison results"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pyglotaran_branch:
+        description: "pyglotaran branch/tag to run the examples against"
+        required: true
+        default: "v0.4.0"
+      pyglotaran_examples_branch:
+        description: "pyglotaran-examples branch/tag to use"
+        required: true
+        default: "main"
+
+jobs:
+  run-examples:
+    name: "Run Example: "
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example_name:
+          [
+            quick-start,
+            fluorescence,
+            transient-absorption,
+            transient-absorption-two-datasets,
+            spectral-constraints,
+            spectral-guidance,
+            two-datasets,
+            sim-3d-disp,
+            sim-3d-nodisp,
+            sim-3d-weight,
+            sim-6d-disp,
+          ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: "glotaran/pyglotaran"
+          ref: ${{ github.event.inputs.pyglotaran_branch }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install pyglotaran
+        run: |
+          pip install wheel
+          pip install .
+      - name: Cloning pyglotaran-examples
+        if: ${{ github.event.inputs.pyglotaran_examples_branch }} == ""
+        uses: actions/checkout@v2
+        with:
+          path: pyglotaran-examples
+      - id: example-run
+        uses: glotaran/pyglotaran-examples@main
+        with:
+          example_name: ${{ matrix.example_name }}
+          examples_branch: ${{ github.event.inputs.pyglotaran_examples_branch }}
+
+      # Needed since plots with timestamps would pollute results
+      - name: Delete result Plots
+        shell: python
+        run: |
+          from pathlib import Path
+
+          results_path = Path.home() / "pyglotaran_examples_results"
+
+          for file in results_path.rglob("*"):
+              if file.is_file() and file.suffix == ".pdf":
+                  print(f"Deleting: {file}")
+                  file.unlink()
+
+      - name: Upload Example Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: example-results
+          path: ~/pyglotaran_examples_results
+
+  upload-results:
+    name: "Upload to comparison-results branch"
+    runs-on: ubuntu-latest
+    needs: [run-examples]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: "glotaran/pyglotaran-examples"
+          ref: "comparison-results"
+      - name: Download results
+        uses: actions/download-artifact@v2
+        with:
+          name: example-results
+          path: .
+      - name: Commit new results
+        run: |
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git add .
+          git commit -m "⬆️ Update results using glotaran branch/tag: ${{ github.event.inputs.pyglotaran_branch }}"
+
+      - name: Push to comparison-results branch
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.BENCHMARK_PUSH_TOKEN }}
+          repository: "glotaran/pyglotaran-examples"
+          branch: "comparison-results"

--- a/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
+++ b/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
@@ -29,8 +29,13 @@ for key, val in MODEL_PATHS.items():
     model = load_model(script_folder.joinpath(val["model"]))
     parameters = load_parameters(script_folder.joinpath(val["parameters"]))
     print(model.markdown(parameters=parameters))
-    scheme = Scheme(model, parameters, {"dataset1": dataset})
+    scheme = Scheme(
+        model, parameters, {"dataset1": dataset}, maximum_number_function_evaluations=5
+    )
     result = optimize(scheme)
+    save_result(
+        result, results_folder / f"{key}_first_run", format_name="legacy", allow_overwrite=True
+    )
     # Second optimization with results of the first:
     scheme2 = result.get_scheme()
     result2 = optimize(scheme2)

--- a/pyglotaran_examples/quick_start/quickstart.py
+++ b/pyglotaran_examples/quick_start/quickstart.py
@@ -28,7 +28,14 @@ print(model.validate(parameters=parameters))
 print(model)
 print(parameters)
 
-result = optimize(Scheme(model, parameters, {"dataset1": dataset}))
+result = optimize(
+    Scheme(
+        model,
+        parameters,
+        {"dataset1": dataset},
+        maximum_number_function_evaluations=3,
+    )
+)
 print(result)
 print(result.optimized_parameters)
 result_dataset = result.data["dataset1"]

--- a/pyglotaran_examples/study_fluorescence/target_analysis_script.py
+++ b/pyglotaran_examples/study_fluorescence/target_analysis_script.py
@@ -47,7 +47,7 @@ else:
         model,
         parameter,
         {"dataset1": dataset},
-        maximum_number_function_evaluations=9,
+        maximum_number_function_evaluations=6,
         non_negative_least_squares=True,
     )
 

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
@@ -43,7 +43,7 @@ scheme = Scheme(
     model,
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2, "dataset3": dataset3},
-    maximum_number_function_evaluations=99,
+    maximum_number_function_evaluations=2,
     non_negative_least_squares=True,
     # optimization_method="Levenberg-Marquardt",
 )

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
@@ -43,7 +43,7 @@ scheme = Scheme(
     model,
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2, "dataset3": dataset3},
-    maximum_number_function_evaluations=99,
+    maximum_number_function_evaluations=2,
     non_negative_least_squares=True,
     # optimization_method="Levenberg-Marquardt",
 )

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
@@ -43,7 +43,7 @@ scheme = Scheme(
     model,
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2, "dataset3": dataset3},
-    maximum_number_function_evaluations=99,
+    maximum_number_function_evaluations=2,
     non_negative_least_squares=True,
     # optimization_method="Levenberg-Marquardt",
 )

--- a/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
@@ -55,7 +55,7 @@ scheme = Scheme(
         "dataset5": dataset5,
         "dataset6": dataset6,
     },
-    maximum_number_function_evaluations=99,
+    maximum_number_function_evaluations=37,
     non_negative_least_squares=True,
     optimization_method="Levenberg-Marquardt",
 )


### PR DESCRIPTION
Limiting the `maximum_number_function_evaluations` will make the results more deterministic and allow us to compare new results with a "gold standard" we set (e.g. `0.4.0`).

To update that "gold standard" I added a workflow that we can manually trigger by `workflow_dispatch` to create new results and upload them to the branch `comparison-results` which only contains the results.
This branch can then be used by the `pyglotaran` CI to validate result consistency.

I didn't change the `maximum_number_function_evaluations` for the cases in `pyglotaran_examples/test` (currently 99) , maybe you have an idea for sensible values.
E.g. we could fix them to the `maximum_number_function_evaluations` it took them to converge with `pyglotaran==0.4.0` as I did for the other cases.

