### PR TITLE
🩹 Fix already saved plots being appended to each pdf

### DIFF
--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -29,6 +29,7 @@ def save_all_figures(filename: str):
     pp = PdfPages(result_file)
     [plt.figure(n).savefig(pp, format="pdf") for n in plt.get_fignums()]
     pp.close()
+    [plt.figure(n).clear() for n in plt.get_fignums()]
     print(f"Saved plotting result to: {result_file}")
 
 


### PR DESCRIPTION
Currently, when running `python scripts/run_examples.py run-all --headless` the plots aren't created in-between example runs, which results in ever-growing pdf sizes and duplication of the plots.

This PR changes the behavior to clear out **after** they were saved to PDF, reducing the size of `plot_results` from 117MB to 20MB. As a side-effect running the examples all together should also be faster.