### PR TITLE
🩹 Fix adding empty pages to PDF

### DIFF
--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -29,7 +29,7 @@ def save_all_figures(filename: str):
     pp = PdfPages(result_file)
     [plt.figure(n).savefig(pp, format="pdf") for n in plt.get_fignums()]
     pp.close()
-    [plt.figure(n).clear() for n in plt.get_fignums()]
+    [plt.close(plt.figure(n)) for n in plt.get_fignums()]
     print(f"Saved plotting result to: {result_file}")
 
 


### PR DESCRIPTION
Follow-up PR for #38, where the duplicate plots were removed but empty pages were still added.
By using `plt.close(fig)` the old figures will be removed from `plt.get_fignums()`, so only the intended plots get added to the summary PDF.