### PR TITLE
👌 Refine action and "Update comparison results" workflow for reproducibility

### DIFF
--- a/.github/workflows/update_compare_results.yml
+++ b/.github/workflows/update_compare_results.yml
@@ -91,7 +91,7 @@ jobs:
           repository: "glotaran/pyglotaran-examples"
           ref: "comparison-results"
       - name: Remove obsolete results
-        run: rm -r *
+        run: rm -r * || true
       - name: Download results
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/update_compare_results.yml
+++ b/.github/workflows/update_compare_results.yml
@@ -50,7 +50,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: pyglotaran-examples
-      - id: example-run
+      - name: "Run Example: ${{ matrix.example_name }}"
+        id: example-run
         uses: glotaran/pyglotaran-examples@main
         with:
           example_name: ${{ matrix.example_name }}
@@ -68,6 +69,11 @@ jobs:
               if file.is_file() and file.suffix == ".pdf":
                   print(f"Deleting: {file}")
                   file.unlink()
+
+      - name: Save Examples commit sha
+        run: |
+          git log -n 1 --pretty=format:%H >> ~/pyglotaran_examples_results/pyglotaran_commit_sha.txt
+        shell: bash
 
       - name: Upload Example Results
         uses: actions/upload-artifact@v2
@@ -96,7 +102,10 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git config user.name 'github-actions[bot]'
           git add .
-          git commit -m "⬆️ Update results using glotaran branch/tag: ${{ github.event.inputs.pyglotaran_branch }}"
+          git commit \
+            -m "⬆️ Update results using glotaran branch/tag: ${{ github.event.inputs.pyglotaran_branch }}" \
+            -m "👌 pyglotaran-examples commit: $(< example_commit_sha.txt)" \
+            -m "👌 pyglotaran commit: $(< pyglotaran_commit_sha.txt)" \
 
       - name: Push to comparison-results branch
         uses: ad-m/github-push-action@v0.6.0

--- a/action.yml
+++ b/action.yml
@@ -47,3 +47,13 @@ runs:
         echo "::set-output name=plots-path::pyglotaran-examples/plot_results"
         echo "::endgroup::"
       shell: bash
+    - name: Save Examples commit sha
+      run: |
+        echo "::group:: Saving commit sha to ~/pyglotaran_examples_results"
+        mkdir -p ~/pyglotaran_examples_results
+        git --git-dir=pyglotaran-examples/.git log -n 1 --pretty=format:%H >> ~/pyglotaran_examples_results/example_commit_sha.txt
+        echo "::endgroup::"
+        echo "::group:: Saving commit sha to plot_results"
+        git --git-dir=pyglotaran-examples/.git log -n 1 --pretty=format:%H >> pyglotaran-examples/plot_results/example_commit_sha.txt
+        echo "::endgroup::"
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -51,9 +51,14 @@ runs:
       run: |
         echo "::group:: Saving commit sha to ~/pyglotaran_examples_results"
         mkdir -p ~/pyglotaran_examples_results
-        git --git-dir=pyglotaran-examples/.git log -n 1 --pretty=format:%H >> ~/pyglotaran_examples_results/example_commit_sha.txt
+        git --git-dir=pyglotaran-examples/.git log -n 1 --pretty=format:%H | \
+          tee ~/pyglotaran_examples_results/example_commit_sha.txt && \
+          echo
         echo "::endgroup::"
+
         echo "::group:: Saving commit sha to plot_results"
-        git --git-dir=pyglotaran-examples/.git log -n 1 --pretty=format:%H >> pyglotaran-examples/plot_results/example_commit_sha.txt
+        git --git-dir=pyglotaran-examples/.git log -n 1 --pretty=format:%H | \
+          tee pyglotaran-examples/plot_results/example_commit_sha.txt && \
+          echo
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
For proper reproducibility, we need to know the exact versions (git commit) of `pyglotaran` and `pyglotaran-examples` that produced the results.
This PR changes the action and "Update comparison results" workflow to extract the commit shas and save them to file as well as the commit message of commits on the `comparison-results` branch.

I also cleaned out the commits on the `comparison-results` branch, since they weren't reproducible due to the missing information.

This is [an example commit](https://github.com/s-weigand/pyglotaran-examples/commit/e1a586082c83f114c0e7233aeb113626ed478b6b) to the empty `comparison-results` branch on my fork.