### PR TITLE
🩹🗑️ Fixed usage of deprecated functionality and syntax

### DIFF
--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
@@ -51,7 +51,7 @@ def run_doas_model(show_plot=False, block_plot=False):
     print(f"\n{'#'*3} DOAS Model - Optimized Parameters {'#'*3}\n")
     print(result.optimized_parameters)
 
-    save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+    save_result(result, results_folder / "result.yml", allow_overwrite=True)
 
     plot_style = PlotStyle()
     plt.rc("axes", prop_cycle=plot_style.cycler)

--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
@@ -5,11 +5,11 @@ from datetime import datetime
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
@@ -11,7 +11,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -40,7 +40,6 @@ def run_doas_model(show_plot=False, block_plot=False):
         model=model,
         parameters=parameters,
         data={"dataset1": dataset},
-        non_negative_least_squares=False,
         optimization_method="TrustRegionReflection",
         # maximum_number_function_evaluations=3,
         maximum_number_function_evaluations=1,
@@ -61,7 +60,7 @@ def run_doas_model(show_plot=False, block_plot=False):
         plot_style = PlotStyle()
         plt.rc("axes", prop_cycle=plot_style.cycler)
 
-        fig = plot_overview(result.data["dataset1"], linlog=True)
+        fig, _ = plot_overview(result.data["dataset1"], linlog=True, figure_only=False)
         plt.rcParams["figure.figsize"] = (21, 14)
 
         timestamp = datetime.now().strftime("%y%m%d_%H%M")

--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta.py
@@ -35,6 +35,7 @@ def run_doas_model(show_plot=False, block_plot=False):
 
     print(f"\n{'#'*10} DOAS Model {'#'*10}\n")
     print(model.validate(parameters=parameters))
+    assert model.valid(parameters=parameters)
 
     scheme = Scheme(
         model=model,

--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta_ascii.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta_ascii.py
@@ -51,7 +51,7 @@ def run_doas_model(show_plot=False, block_plot=False):
     print(f"\n{'#'*3} DOAS Model - Optimized Parameters {'#'*3}\n")
     print(result.optimized_parameters)
 
-    save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+    save_result(result, results_folder / "result.yml", allow_overwrite=True)
 
     plot_style = PlotStyle()
     plt.rc("axes", prop_cycle=plot_style.cycler)

--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta_ascii.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta_ascii.py
@@ -5,11 +5,11 @@ from datetime import datetime
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/ex_doas_beta/ex_doas_beta_ascii.py
+++ b/pyglotaran_examples/ex_doas_beta/ex_doas_beta_ascii.py
@@ -11,7 +11,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -40,7 +40,6 @@ def run_doas_model(show_plot=False, block_plot=False):
         model=model,
         parameters=parameters,
         data={"dataset1": dataset},
-        non_negative_least_squares=False,
         optimization_method="TrustRegionReflection",
         # maximum_number_function_evaluations=3,
         maximum_number_function_evaluations=7,
@@ -61,7 +60,7 @@ def run_doas_model(show_plot=False, block_plot=False):
         plot_style = PlotStyle()
         plt.rc("axes", prop_cycle=plot_style.cycler)
 
-        fig = plot_overview(result.data["dataset1"], linlog=True)
+        fig, _ = plot_overview(result.data["dataset1"], linlog=True, figure_only=False)
         plt.rcParams["figure.figsize"] = (21, 14)
 
         timestamp = datetime.now().strftime("%y%m%d_%H%M")

--- a/pyglotaran_examples/ex_doas_beta/models/model.yml
+++ b/pyglotaran_examples/ex_doas_beta/models/model.yml
@@ -6,89 +6,91 @@ initial_concentration:
     parameters: [j.1, j.0, j.0]
 
 k_matrix:
-    k1:
-      matrix:
-        '(hotS1, S2)': kinetic.1
-        '(S1, hotS1)': kinetic.2
-        '(S1, S1)': kinetic.3
+  k1:
+    matrix:
+      "(hotS1, S2)": kinetic.1
+      "(S1, hotS1)": kinetic.2
+      "(S1, S1)": kinetic.3
 
 megacomplex:
   doas:
     type: damped-oscillation
-    labels: [
-      osc1,
-      osc2,
-      osc3,
-      osc4,
-      osc5,
-      osc6,
-      osc7,
-      osc8,
-      osc9,
-      osc10,
-      osc11,
-      osc12,
-      osc13,
-      osc14,
-      osc15,
-      osc16,
-      osc17,
-      osc18,
-      osc19,
-    ]
-    frequencies: [
-      osc.freq.1,
-      osc.freq.2,
-      osc.freq.3,
-      osc.freq.4,
-      osc.freq.5,
-      osc.freq.6,
-      osc.freq.7,
-      osc.freq.8,
-      osc.freq.9,
-      osc.freq.10,
-      osc.freq.11,
-      osc.freq.12,
-      osc.freq.13,
-      osc.freq.14,
-      osc.freq.15,
-      osc.freq.16,
-      osc.freq.17,
-      osc.freq.18,
-      osc.freq.19,
-    ]
-    rates: [
-      osc.rates.1,
-      osc.rates.2,
-      osc.rates.3,
-      osc.rates.4,
-      osc.rates.5,
-      osc.rates.6,
-      osc.rates.7,
-      osc.rates.8,
-      osc.rates.9,
-      osc.rates.10,
-      osc.rates.11,
-      osc.rates.12,
-      osc.rates.13,
-      osc.rates.14,
-      osc.rates.15,
-      osc.rates.16,
-      osc.rates.17,
-      osc.rates.18,
-      osc.rates.19,
-    ]
+    labels:
+      [
+        osc1,
+        osc2,
+        osc3,
+        osc4,
+        osc5,
+        osc6,
+        osc7,
+        osc8,
+        osc9,
+        osc10,
+        osc11,
+        osc12,
+        osc13,
+        osc14,
+        osc15,
+        osc16,
+        osc17,
+        osc18,
+        osc19,
+      ]
+    frequencies:
+      [
+        osc.freq.1,
+        osc.freq.2,
+        osc.freq.3,
+        osc.freq.4,
+        osc.freq.5,
+        osc.freq.6,
+        osc.freq.7,
+        osc.freq.8,
+        osc.freq.9,
+        osc.freq.10,
+        osc.freq.11,
+        osc.freq.12,
+        osc.freq.13,
+        osc.freq.14,
+        osc.freq.15,
+        osc.freq.16,
+        osc.freq.17,
+        osc.freq.18,
+        osc.freq.19,
+      ]
+    rates:
+      [
+        osc.rates.1,
+        osc.rates.2,
+        osc.rates.3,
+        osc.rates.4,
+        osc.rates.5,
+        osc.rates.6,
+        osc.rates.7,
+        osc.rates.8,
+        osc.rates.9,
+        osc.rates.10,
+        osc.rates.11,
+        osc.rates.12,
+        osc.rates.13,
+        osc.rates.14,
+        osc.rates.15,
+        osc.rates.16,
+        osc.rates.17,
+        osc.rates.18,
+        osc.rates.19,
+      ]
   decay:
     type: decay
     k_matrix: [k1]
-#  baseline:
-#    type: baseline
-#    dimension: time
+  #  baseline:
+  #    type: baseline
+  #    dimension: time
   artifact:
     type: coherent-artifact
     order: 3
     width: artifact.CAwidth
-
 
 irf:
   irf1:
@@ -96,7 +98,7 @@ irf:
     center: irf.center
     width: irf.width
     dispersion_center: irf.dispcenter
-    center_dispersion: [irf.disp1, irf.disp2]
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
     model_dispersion_with_wavenumber: true
 
 dataset:

--- a/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
+++ b/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
@@ -36,13 +36,11 @@ for key, val in MODEL_PATHS.items():
         maximum_number_function_evaluations=7,  # TRF needs at least 6
     )
     result = optimize(scheme)
-    save_result(
-        result, results_folder / f"{key}_first_run", format_name="legacy", allow_overwrite=True
-    )
+    save_result(result, results_folder / f"{key}_first_run" / "result.yml", allow_overwrite=True)
     # Second optimization with results of the first:
     scheme2 = result.get_scheme()
     result2 = optimize(scheme2)
-    save_result(result2, results_folder / key, format_name="legacy", allow_overwrite=True)
+    save_result(result2, results_folder / key / "result.yml", allow_overwrite=True)
     plot_simple_overview(result.data["dataset1"], key, figure_only=False)
     plot_simple_overview(result2.data["dataset1"], key, figure_only=False)
 plt.show()

--- a/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
+++ b/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
@@ -1,10 +1,10 @@
 # %%
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_simple_overview

--- a/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
+++ b/pyglotaran_examples/ex_spectral_constraints/ex_spectral_constraints.py
@@ -6,7 +6,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_simple_overview
 
 DATA_PATH = "data/data.ascii"
@@ -43,6 +43,6 @@ for key, val in MODEL_PATHS.items():
     scheme2 = result.get_scheme()
     result2 = optimize(scheme2)
     save_result(result2, results_folder / key, format_name="legacy", allow_overwrite=True)
-    plot_simple_overview(result.data["dataset1"], key)
-    plot_simple_overview(result2.data["dataset1"], key)
+    plot_simple_overview(result.data["dataset1"], key, figure_only=False)
+    plot_simple_overview(result2.data["dataset1"], key, figure_only=False)
 plt.show()

--- a/pyglotaran_examples/ex_spectral_constraints/models/model.yml
+++ b/pyglotaran_examples/ex_spectral_constraints/models/model.yml
@@ -23,6 +23,6 @@ initial_concentration:
 
 irf:
   irf1:
-    type: spectral-multi-gaussian # TODO: also make gaussian work
-    center: [irf.center]
-    width: [irf.width]
+    type: gaussian
+    center: irf.center
+    width: irf.width

--- a/pyglotaran_examples/ex_spectral_constraints/models/model.yml
+++ b/pyglotaran_examples/ex_spectral_constraints/models/model.yml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default_megacomplex: decay
 
 dataset:
   dataset1:

--- a/pyglotaran_examples/ex_spectral_constraints/models/model_equal_area_penalties.yml
+++ b/pyglotaran_examples/ex_spectral_constraints/models/model_equal_area_penalties.yml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default_megacomplex: decay
 
 dataset:
   dataset1:
@@ -27,7 +27,7 @@ irf:
     center: [irf.center]
     width: [irf.width]
 
-equal_area_penalties:
+clp_area_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[0, 1000]]

--- a/pyglotaran_examples/ex_spectral_constraints/models/model_equal_area_penalties.yml
+++ b/pyglotaran_examples/ex_spectral_constraints/models/model_equal_area_penalties.yml
@@ -23,11 +23,11 @@ initial_concentration:
 
 irf:
   irf1:
-    type: spectral-multi-gaussian
-    center: [irf.center]
-    width: [irf.width]
+    type: gaussian
+    center: irf.center
+    width: irf.width
 
-clp_area_penalties:
+clp_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[0, 1000]]

--- a/pyglotaran_examples/ex_spectral_constraints/models/model_equal_area_penalties.yml
+++ b/pyglotaran_examples/ex_spectral_constraints/models/model_equal_area_penalties.yml
@@ -27,7 +27,7 @@ irf:
     center: irf.center
     width: irf.width
 
-clp_penalties:
+clp_area_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[0, 1000]]

--- a/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
+++ b/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
@@ -8,7 +8,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -39,7 +39,6 @@ def main():
         {"dataset1": dataset1, "dataset2": dataset2},
         # optimization_method="Levenberg-Marquardt", # LM needs more nfev!
         maximum_number_function_evaluations=23,  # TRF needs nfev=21-23
-        non_negative_least_squares=True,
     )
 
     # Optimize the analysis scheme (and estimate parameters)
@@ -62,15 +61,15 @@ def load_and_plot_results():
     print(f"Optimized parameters:\n {parameters}")
 
     result1 = results_folder.joinpath("dataset1.nc")
-    fig1 = plot_overview(result1, linlog=True, show_data=True)
-    timestamp = datetime.now().strftime("%y%m%d_%H%M")
+    fig1, _ = plot_overview(result1, linlog=True, show_data=True, figure_only=False)
+    timestamp = datetime.today().strftime("%y%m%d_%H%M")
     fig1.savefig(
         results_folder.joinpath(f"plot_overview_1of2_{timestamp}.pdf"), bbox_inches="tight"
     )
 
     result2 = results_folder.joinpath("dataset2.nc")
-    fig2 = plot_overview(result2, linlog=True)
-    timestamp = datetime.now().strftime("%y%m%d_%H%M")
+    fig2, _ = plot_overview(result2, linlog=True, figure_only=False)
+    timestamp = datetime.today().strftime("%y%m%d_%H%M")
     fig2.savefig(
         results_folder.joinpath(f"plot_overview_2of2_{timestamp}.pdf"), bbox_inches="tight"
     )

--- a/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
+++ b/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
@@ -62,14 +62,14 @@ def load_and_plot_results():
 
     result1 = results_folder.joinpath("dataset1.nc")
     fig1, _ = plot_overview(result1, linlog=True, show_data=True, figure_only=False)
-    timestamp = datetime.today().strftime("%y%m%d_%H%M")
+    timestamp = datetime.now().strftime("%y%m%d_%H%M")
     fig1.savefig(
         results_folder.joinpath(f"plot_overview_1of2_{timestamp}.pdf"), bbox_inches="tight"
     )
 
     result2 = results_folder.joinpath("dataset2.nc")
     fig2, _ = plot_overview(result2, linlog=True, figure_only=False)
-    timestamp = datetime.today().strftime("%y%m%d_%H%M")
+    timestamp = datetime.now().strftime("%y%m%d_%H%M")
     fig2.savefig(
         results_folder.joinpath(f"plot_overview_2of2_{timestamp}.pdf"), bbox_inches="tight"
     )

--- a/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
+++ b/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
@@ -79,5 +79,5 @@ def load_and_plot_results():
 if __name__ == "__main__":
     print(f"- Using folder {results_folder.name} to read/write files for this run")
     result = main()
-    save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+    save_result(result, results_folder / "result.yml", allow_overwrite=True)
     load_and_plot_results()

--- a/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
+++ b/pyglotaran_examples/ex_spectral_guidance/ex_spectral_guidance.py
@@ -2,11 +2,11 @@
 from datetime import datetime
 
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
+++ b/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default_megacomplex: decay
 
 dataset:
   dataset1:
@@ -9,7 +9,7 @@ dataset:
   dataset2:
     megacomplex: [complex2]
     initial_concentration: input2
-#    irf: None
+    #    irf: None
     scale: scale.2
 
 megacomplex:
@@ -35,12 +35,13 @@ k_matrix:
 initial_concentration:
   input1:
     compartments: [s1, s2, s3, s4, s5, s6]
-    parameters: [inputs.s1, inputs.s1, inputs.s1, inputs.s2, inputs.s1, inputs.s1]
+    parameters:
+      [inputs.s1, inputs.s1, inputs.s1, inputs.s2, inputs.s1, inputs.s1]
   input2:
     compartments: [s5]
     parameters: [inputs.s2]
 
-equal_area_penalties:
+clp_area_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[0, 1000]]
@@ -49,7 +50,7 @@ equal_area_penalties:
     parameter: area.1
     weight: 1.E-6
 
-spectral_relations:
+clp_relations:
   - compartment: s1
     target: s4
     parameter: rel.r1

--- a/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
+++ b/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
@@ -1,5 +1,10 @@
 default_megacomplex: decay
 
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
+    # link_clp: false
+
 dataset:
   dataset1:
     megacomplex: [complex1]
@@ -51,11 +56,11 @@ clp_area_penalties:
     weight: 1.E-6
 
 clp_relations:
-  - compartment: s1
+  - source: s1
     target: s4
     parameter: rel.r1
     interval: [[0, 1000]]
-  - compartment: s3
+  - source: s3
     target: s6
     parameter: rel.r1
     interval: [[0, 1000]]

--- a/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
+++ b/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
@@ -67,6 +67,6 @@ clp_relations:
 
 irf:
   irf1:
-    type: spectral-multi-gaussian
-    center: [irf.center]
-    width: [irf.width]
+    type: gaussian
+    center: irf.center
+    width: irf.width

--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -3,11 +3,11 @@
 from datetime import datetime
 
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -73,11 +73,11 @@ except (ValueError, FileExistsError) as error:
 plot_style = PlotStyle()
 plt.rc("axes", prop_cycle=plot_style.cycler)
 
-fig1 = plot_overview(result.data["dataset1"], linlog=True)
+fig1, _ = plot_overview(result.data["dataset1"], linlog=True, figure_only=False)
 timestamp = datetime.now().strftime("%y%m%d_%H%M")
 fig1.savefig(results_folder.joinpath(f"plot_overview_1of2_{timestamp}.pdf"), bbox_inches="tight")
 
-fig2 = plot_overview(result.data["dataset2"], linlog=True)
+fig2, _ = plot_overview(result.data["dataset2"], linlog=True, figure_only=False)
 timestamp = datetime.now().strftime("%y%m%d_%H%M")
 fig2.savefig(results_folder.joinpath(f"plot_overview_2of2_{timestamp}.pdf"), bbox_inches="tight")
 

--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -75,11 +75,11 @@ plot_style = PlotStyle()
 plt.rc("axes", prop_cycle=plot_style.cycler)
 
 fig1 = plot_overview(result.data["dataset1"], linlog=True)
-timestamp = datetime.today().strftime("%y%m%d_%H%M")
+timestamp = datetime.now().strftime("%y%m%d_%H%M")
 fig1.savefig(results_folder.joinpath(f"plot_overview_1of2_{timestamp}.pdf"), bbox_inches="tight")
 
 fig2 = plot_overview(result.data["dataset2"], linlog=True)
-timestamp = datetime.today().strftime("%y%m%d_%H%M")
+timestamp = datetime.now().strftime("%y%m%d_%H%M")
 fig2.savefig(results_folder.joinpath(f"plot_overview_2of2_{timestamp}.pdf"), bbox_inches="tight")
 
 plt.show()

--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -54,7 +54,7 @@ print(result.markdown(True))
 
 # %% Save the results
 try:
-    save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+    save_result(result, results_folder / "result.yml", allow_overwrite=True)
 except (ValueError, FileExistsError) as error:
     print(f"catching error: {error}")
     try:

--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -9,7 +9,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -75,11 +75,11 @@ plot_style = PlotStyle()
 plt.rc("axes", prop_cycle=plot_style.cycler)
 
 fig1 = plot_overview(result.data["dataset1"], linlog=True)
-timestamp = datetime.now().strftime("%y%m%d_%H%M")
+timestamp = datetime.today().strftime("%y%m%d_%H%M")
 fig1.savefig(results_folder.joinpath(f"plot_overview_1of2_{timestamp}.pdf"), bbox_inches="tight")
 
 fig2 = plot_overview(result.data["dataset2"], linlog=True)
-timestamp = datetime.now().strftime("%y%m%d_%H%M")
+timestamp = datetime.today().strftime("%y%m%d_%H%M")
 fig2.savefig(results_folder.joinpath(f"plot_overview_2of2_{timestamp}.pdf"), bbox_inches="tight")
 
 plt.show()

--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -39,7 +39,6 @@ scheme = Scheme(
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2},
     maximum_number_function_evaluations=18,
-    non_negative_least_squares=True,
     optimization_method="TrustRegionReflection",
 )
 

--- a/pyglotaran_examples/ex_two_datasets/models/model.yml
+++ b/pyglotaran_examples/ex_two_datasets/models/model.yml
@@ -1,4 +1,9 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
+    # link_clp: false
 
 dataset:
   dataset1:
@@ -41,8 +46,8 @@ irf:
     center: [irf.center]
     width: [irf.width]
 
-# It works without equal_area_penalties but then the inputs cannot be estimated
-equal_area_penalties:
+# It works without clp_area_penalties but then the inputs cannot be estimated
+clp_area_penalties:
   - type: equal_area
     source: s1
     source_intervals: [[300, 3000]]
@@ -57,7 +62,6 @@ equal_area_penalties:
     target_intervals: [[300, 3000]]
     parameter: area.1
     weight: 0.1
-
 # Example of weight application:
 # weights:
 #   - datasets: [dataset1, dataset2]

--- a/pyglotaran_examples/ex_two_datasets/models/model.yml
+++ b/pyglotaran_examples/ex_two_datasets/models/model.yml
@@ -38,13 +38,13 @@ initial_concentration:
 
 irf:
   irf1:
-    type: spectral-multi-gaussian
-    center: [irf.center]
-    width: [irf.width]
+    type: gaussian
+    center: irf.center
+    width: irf.width
   irf1_no_dispersion:
-    type: spectral-multi-gaussian
-    center: [irf.center]
-    width: [irf.width]
+    type: gaussian
+    center: irf.center
+    width: irf.width
 
 # It works without clp_area_penalties but then the inputs cannot be estimated
 clp_area_penalties:

--- a/pyglotaran_examples/quick_start/model.yml
+++ b/pyglotaran_examples/quick_start/model.yml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default_megacomplex: decay
 
 initial_concentration:
   input:

--- a/pyglotaran_examples/quick_start/quickstart.py
+++ b/pyglotaran_examples/quick_start/quickstart.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-from glotaran.analysis.optimize import optimize
 from glotaran.examples.sequential import dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import prepare_time_trace_dataset
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 
 script_dir = Path(__file__).resolve().parent

--- a/pyglotaran_examples/quick_start/quickstart.py
+++ b/pyglotaran_examples/quick_start/quickstart.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-from glotaran.examples.sequential import dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import prepare_time_trace_dataset
 from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
+from glotaran.testing.simulated_data.sequential_spectral_decay import DATASET as dataset
 
 script_dir = Path(__file__).resolve().parent
 print(f"Script folder: {script_dir}")

--- a/pyglotaran_examples/study_fluorescence/models/model-target.yaml
+++ b/pyglotaran_examples/study_fluorescence/models/model-target.yaml
@@ -52,7 +52,7 @@ clp_constraints:
       - [1, 690]
 #  - [zero, s1, (1, 100), (2, 200)]
 
-clp_penalties:
+clp_area_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[100, 1000]]

--- a/pyglotaran_examples/study_fluorescence/models/model-target.yaml
+++ b/pyglotaran_examples/study_fluorescence/models/model-target.yaml
@@ -52,7 +52,7 @@ clp_constraints:
       - [1, 690]
 #  - [zero, s1, (1, 100), (2, 200)]
 
-clp_area_penalties:
+clp_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[100, 1000]]

--- a/pyglotaran_examples/study_fluorescence/models/model-target.yaml
+++ b/pyglotaran_examples/study_fluorescence/models/model-target.yaml
@@ -1,4 +1,9 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
+    # link_clp: false
 
 megacomplex:
   mc1:
@@ -29,30 +34,25 @@ irf:
 initial_concentration:
   input1:
     compartments: [s1, s2, s3, s4, s5]
-    parameters: [
-      input.1,
-      input.0,
-      input.0,
-      input.0,
-      input.0]
+    parameters: [input.1, input.0, input.0, input.0, input.0]
     # exclude_from_normalize: [s1, s2, s3, s4, s5]
 
-spectral_constraints:
+clp_constraints:
   - type: zero
-    compartment: s1
+    target: s1
     interval:
       - [1, 1000]
   - type: zero
-    compartment: s3
+    target: s3
     interval:
       - [1, 680]
   - type: zero
-    compartment: s4
+    target: s4
     interval:
       - [1, 690]
 #  - [zero, s1, (1, 100), (2, 200)]
 
-equal_area_penalties:
+clp_area_penalties:
   - type: equal_area
     source: s2
     source_intervals: [[100, 1000]]

--- a/pyglotaran_examples/study_fluorescence/models/model.yaml
+++ b/pyglotaran_examples/study_fluorescence/models/model.yaml
@@ -1,4 +1,9 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
+    # link_clp: false
 
 megacomplex:
   mc1:
@@ -23,11 +28,7 @@ irf:
 initial_concentration:
   input1:
     compartments: [s1, s2, s3, s4]
-    parameters: [
-      input.1,
-      input.0,
-      input.0,
-      input.0]
+    parameters: [input.1, input.0, input.0, input.0]
 
 dataset:
   dataset1:

--- a/pyglotaran_examples/study_fluorescence/target_analysis_script.py
+++ b/pyglotaran_examples/study_fluorescence/target_analysis_script.py
@@ -10,7 +10,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -48,8 +48,6 @@ else:
         {"dataset1": dataset},
         maximum_number_function_evaluations=6,  # 6 for TRF, 46 for LM
         # optimization_method="Levenberg-Marquardt", #lm needs nfev=46
-        non_negative_least_squares=True,
-        # group=False
     )
 
     print(model.validate(parameters=parameter))
@@ -79,7 +77,7 @@ plot_style = PlotStyle()
 plt.rc("axes", prop_cycle=plot_style.cycler)
 
 # %%
-fig = plot_overview(result_datafile, linlog=False)
+fig, _ = plot_overview(result_datafile, linlog=False, figure_only=False)
 # note species concentration plot still needs work to match styles between the two locatable axis
 
 # %%

--- a/pyglotaran_examples/study_fluorescence/target_analysis_script.py
+++ b/pyglotaran_examples/study_fluorescence/target_analysis_script.py
@@ -59,7 +59,7 @@ else:
     end = timer()
     print(f"Total time: {end - start}")
 
-    save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+    save_result(result, results_folder / "result.yml", allow_overwrite=True)
     end2 = timer()
     print(f"Saving took: {end2 - end}")
 

--- a/pyglotaran_examples/study_fluorescence/target_analysis_script.py
+++ b/pyglotaran_examples/study_fluorescence/target_analysis_script.py
@@ -4,11 +4,11 @@
 from timeit import default_timer as timer
 
 import matplotlib.pyplot as plt
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/study_transient_absorption/models/model.yml
+++ b/pyglotaran_examples/study_transient_absorption/models/model.yml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default_megacomplex: decay
 
 dataset:
   dataset1:
@@ -31,10 +31,10 @@ irf:
     center: [irf.center]
     width: [irf.width]
     dispersion_center: irf.dispc
-    center_dispersion: [irf.disp1, irf.disp2, irf.disp3] #model validate accepted "dispersion_par" as valid!
+    center_dispersion_coefficients: [irf.disp1, irf.disp2, irf.disp3] #model validate accepted "dispersion_par" as valid!
 
-spectral_relations:
-  - compartment: s2
+clp_relations:
+  - source: s2
     target: s3
     parameter: rel.r1
     interval: [[0, 1000]]

--- a/pyglotaran_examples/study_transient_absorption/models/model_2d_co_co2.yml
+++ b/pyglotaran_examples/study_transient_absorption/models/model_2d_co_co2.yml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default_megacomplex: decay
 
 dataset:
   dataset1:
@@ -49,16 +49,16 @@ irf:
     center: [irf.center]
     width: [irf.width]
     dispersion_center: irf.dispc
-    center_dispersion: [irf.disp1, irf.disp2, irf.disp3] #model validate accepted "dispersion_par" as valid!
+    center_dispersion_coefficients: [irf.disp1, irf.disp2, irf.disp3] #model validate accepted "dispersion_par" as valid!
   irf2:
     type: spectral-multi-gaussian
     center: [irf2.center]
     width: [irf.width]
     dispersion_center: irf.dispc
-    center_dispersion: [irf.disp1, irf.disp2, irf.disp3] #model validate accepted "dispersion_par" as valid!
+    center_dispersion_coefficients: [irf.disp1, irf.disp2, irf.disp3] #model validate accepted "dispersion_par" as valid!
 
-spectral_relations:
-  - compartment: s2
+clp_relations:
+  - source: s2
     target: s3
     parameter: rel.r1
     interval: [[0, 1000]]

--- a/pyglotaran_examples/study_transient_absorption/target_analysis_script.py
+++ b/pyglotaran_examples/study_transient_absorption/target_analysis_script.py
@@ -39,7 +39,7 @@ result = optimize(scheme)
 print(result.markdown(True))
 
 # %% Save the results
-save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+save_result(result, results_folder / "result.yml", allow_overwrite=True)
 
 # %% Plot and save as PDF
 # This set subsequent plots to the glotaran style

--- a/pyglotaran_examples/study_transient_absorption/target_analysis_script.py
+++ b/pyglotaran_examples/study_transient_absorption/target_analysis_script.py
@@ -8,7 +8,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -46,7 +46,7 @@ save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
 plot_style = PlotStyle()
 plt.rc("axes", prop_cycle=plot_style.cycler)
 
-fig = plot_overview(result, linlog=True)
+fig, _ = plot_overview(result, linlog=True, figure_only=False)
 
 timestamp = datetime.now().strftime("%y%m%d_%H%M")
 fig.savefig(results_folder.joinpath(f"plot_overview_{timestamp}.pdf"), bbox_inches="tight")

--- a/pyglotaran_examples/study_transient_absorption/target_analysis_script.py
+++ b/pyglotaran_examples/study_transient_absorption/target_analysis_script.py
@@ -2,11 +2,11 @@
 from datetime import datetime
 
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/study_transient_absorption/two_dataset_analysis.py
+++ b/pyglotaran_examples/study_transient_absorption/two_dataset_analysis.py
@@ -5,11 +5,11 @@ from timeit import default_timer as timer
 
 # Needed for plotting only
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/study_transient_absorption/two_dataset_analysis.py
+++ b/pyglotaran_examples/study_transient_absorption/two_dataset_analysis.py
@@ -65,7 +65,7 @@ result = optimize(scheme)
 end = timer()
 print(f"Total time: {end - start}")
 
-save_result(result, output_folder, format_name="legacy", allow_overwrite=True)
+save_result(result, output_folder / "result.yml", allow_overwrite=True)
 end2 = timer()
 print(f"Saving took: {end2 - end}")
 

--- a/pyglotaran_examples/study_transient_absorption/two_dataset_analysis.py
+++ b/pyglotaran_examples/study_transient_absorption/two_dataset_analysis.py
@@ -11,7 +11,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -88,13 +88,13 @@ plt.rc("axes", prop_cycle=plot_style.cycler)
 
 # %%
 # TODO: enhance plot_overview to handle multiple datasets
-fig1 = plot_overview(result_datafile1, linlog=True, linthresh=1)
+fig1, _ = plot_overview(result_datafile1, linlog=True, linthresh=1, figure_only=False)
 fig1.savefig(
     output_folder.joinpath(f"plot_overview_{result_name}_d1_{data_path1.stem}.pdf"),
     bbox_inches="tight",
 )
 
-fig2 = plot_overview(result_datafile2, linlog=True, linthresh=1)
+fig2, _ = plot_overview(result_datafile2, linlog=True, linthresh=1, figure_only=False)
 fig2.savefig(
     output_folder.joinpath(f"plot_overview_{result_name}_d2_{data_path2.stem}.pdf"),
     bbox_inches="tight",

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_disp/model.yml
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_disp/model.yml
@@ -1,4 +1,8 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
 
 dataset:
   dataset1:
@@ -19,7 +23,7 @@ dataset:
 
 megacomplex:
   complex1:
-      k_matrix: [km1]
+    k_matrix: [km1]
 
 k_matrix:
   km1:
@@ -29,39 +33,39 @@ k_matrix:
       (s3, s3): rates.k3
 
 initial_concentration:
-    input1:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.2,inputs.3]
-    input2:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.7,inputs.8]
-    input3:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.9,inputs.10]
+  input1:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.2, inputs.3]
+  input2:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.7, inputs.8]
+  input3:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.9, inputs.10]
 #      exclude_from_normalize: [s1, s2, s3]
 
 irf:
   irf1_with_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center1]
-    width : [irf.width]
-    dispersion_center : irf.dispc
-    center_dispersion : [irf.disp1,irf.disp2]
+    type: spectral-multi-gaussian
+    center: [irf.center1]
+    width: [irf.width]
+    dispersion_center: irf.dispc
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
   irf2_with_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center2]
-    width : [irf.width]
-    dispersion_center : irf.dispc
-    center_dispersion : [irf.disp1,irf.disp2]
+    type: spectral-multi-gaussian
+    center: [irf.center2]
+    width: [irf.width]
+    dispersion_center: irf.dispc
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
   irf3_with_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center3]
-    width : [irf.width]
-    dispersion_center : irf.dispc
-    center_dispersion : [irf.disp1,irf.disp2]
+    type: spectral-multi-gaussian
+    center: [irf.center3]
+    width: [irf.width]
+    dispersion_center: irf.dispc
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
 
-    # It works without equal_area_penalties but then the inputs cannot be estimated
-equal_area_penalties:
+    # It works without clp_area_penalties but then the inputs cannot be estimated
+clp_area_penalties:
   - type: equal_area
     source: s1
     source_intervals: [[300, 3000]]
@@ -76,7 +80,6 @@ equal_area_penalties:
     target_intervals: [[300, 3000]]
     parameter: area.1
     weight: 0.1
-
 # weights:
 #   - datasets: [dataset1, dataset2, dataset3]
 #     global_interval: [400, 450]

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
@@ -43,7 +43,7 @@ scheme = Scheme(
 # optimize
 result = optimize(scheme)
 # %% Save results
-save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+save_result(result, results_folder / "result.yml", allow_overwrite=True)
 
 # %% Plot results
 # Set subsequent plots to the glotaran style

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
@@ -1,11 +1,11 @@
 # %%
 # Needed for plotting only
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_disp/sim_analysis_script_3d_disp.py
@@ -7,7 +7,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -38,7 +38,6 @@ scheme = Scheme(
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2, "dataset3": dataset3},
     maximum_number_function_evaluations=5,  # TRF needs nfev=4, LM needs nfev=55
-    non_negative_least_squares=True,
     # optimization_method="Levenberg-Marquardt", # LM needs nfev=55
 )
 # optimize
@@ -55,19 +54,19 @@ plt.rc("axes", prop_cycle=plot_style.cycler)
 result_datafile1 = results_folder.joinpath("dataset1.nc")
 result_datafile2 = results_folder.joinpath("dataset2.nc")
 result_datafile3 = results_folder.joinpath("dataset3.nc")
-fig1 = plot_overview(result_datafile1, linlog=True, linthresh=1)
+fig1, _ = plot_overview(result_datafile1, linlog=True, linthresh=1, figure_only=False)
 fig1.savefig(
     results_folder.joinpath("plot_overview_sim3d_d1.pdf"),
     bbox_inches="tight",
 )
 
-fig2 = plot_overview(result_datafile2, linlog=True, linthresh=1)
+fig2, _ = plot_overview(result_datafile2, linlog=True, linthresh=1, figure_only=False)
 fig2.savefig(
     results_folder.joinpath("plot_overview_sim3d_d2.pdf"),
     bbox_inches="tight",
 )
 
-fig3 = plot_overview(result_datafile3, linlog=True, linthresh=1)
+fig3, _ = plot_overview(result_datafile3, linlog=True, linthresh=1, figure_only=False)
 fig3.savefig(
     results_folder.joinpath("plot_overview_sim3d_d3.pdf"),
     bbox_inches="tight",

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/model.yml
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/model.yml
@@ -1,4 +1,8 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
 
 dataset:
   dataset1:
@@ -19,7 +23,7 @@ dataset:
 
 megacomplex:
   complex1:
-      k_matrix: [km1]
+    k_matrix: [km1]
 
 k_matrix:
   km1:
@@ -29,25 +33,25 @@ k_matrix:
       (s3, s3): rates.k3
 
 initial_concentration:
-    input1:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.2,inputs.3]
-    input2:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.7,inputs.8]
-    input3:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.9,inputs.10]
+  input1:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.2, inputs.3]
+  input2:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.7, inputs.8]
+  input3:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.9, inputs.10]
 #      exclude_from_normalize: [s1, s2, s3]
 
 irf:
   irf1_no_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center]
-    width : [irf.width]
+    type: spectral-multi-gaussian
+    center: [irf.center]
+    width: [irf.width]
 
-    # It works without equal_area_penalties but then the inputs cannot be estimated
-equal_area_penalties:
+    # It works without clp_area_penalties but then the inputs cannot be estimated
+clp_area_penalties:
   - type: equal_area
     source: s1
     source_intervals: [[300, 3000]]

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
@@ -1,11 +1,11 @@
 # %%
 # Needed for plotting only
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
@@ -7,7 +7,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -37,7 +37,6 @@ scheme = Scheme(
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2, "dataset3": dataset3},
     maximum_number_function_evaluations=None,
-    non_negative_least_squares=True,
     # optimization_method="Levenberg-Marquardt",
 )
 # optimize
@@ -54,19 +53,19 @@ plt.rc("axes", prop_cycle=plot_style.cycler)
 result_datafile1 = results_folder.joinpath("dataset1.nc")
 result_datafile2 = results_folder.joinpath("dataset2.nc")
 result_datafile3 = results_folder.joinpath("dataset3.nc")
-fig1 = plot_overview(result_datafile1, linlog=True, linthresh=1)
+fig1, _ = plot_overview(result_datafile1, linlog=True, linthresh=1, figure_only=False)
 fig1.savefig(
     results_folder.joinpath("plot_overview_sim3d_d1.pdf"),
     bbox_inches="tight",
 )
 
-fig2 = plot_overview(result_datafile2, linlog=True, linthresh=1)
+fig2, _ = plot_overview(result_datafile2, linlog=True, linthresh=1, figure_only=False)
 fig2.savefig(
     results_folder.joinpath("plot_overview_sim3d_d2.pdf"),
     bbox_inches="tight",
 )
 
-fig3 = plot_overview(result_datafile3, linlog=True, linthresh=1)
+fig3, _ = plot_overview(result_datafile3, linlog=True, linthresh=1, figure_only=False)
 fig3.savefig(
     results_folder.joinpath("plot_overview_sim3d_d3.pdf"),
     bbox_inches="tight",

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/sim_analysis_script_3d.py
@@ -42,7 +42,7 @@ scheme = Scheme(
 # optimize
 result = optimize(scheme)
 # %% Save results
-save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+save_result(result, results_folder / "result.yml", allow_overwrite=True)
 
 # %% Plot results
 # Set subsequent plots to the glotaran style

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_weight/model.yml
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_weight/model.yml
@@ -1,4 +1,8 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
 
 dataset:
   dataset1:
@@ -53,7 +57,7 @@ irf:
     center: [irf.center3]
     width: [irf.width2]
 
-equal_area_penalties:
+clp_area_penalties:
   - type: equal_area
     source: s1
     source_intervals: [[300, 3000]]
@@ -72,7 +76,7 @@ equal_area_penalties:
 weights:
   - datasets: [dataset2]
     global_interval: [400, 600]
-    value: 0.5  # should be 0.71?
+    value: 0.5 # should be 0.71?
   - datasets: [dataset3]
     global_interval: [400, 600]
-    value: 0.0025  # should be 0.05?
+    value: 0.0025 # should be 0.05?

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
@@ -43,7 +43,7 @@ scheme = Scheme(
 # optimize
 result = optimize(scheme)
 # %% Save results
-save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+save_result(result, results_folder / "result.yml", allow_overwrite=True)
 
 # %% Plot results
 # Set subsequent plots to the glotaran style

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
@@ -7,7 +7,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -38,7 +38,6 @@ scheme = Scheme(
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2, "dataset3": dataset3},
     maximum_number_function_evaluations=111,  # 111, #7 for TRF, 86-103 for LM
-    non_negative_least_squares=True,
     optimization_method="Levenberg-Marquardt",  # lm needs nfev=103 to converge
 )
 # optimize
@@ -55,19 +54,19 @@ plt.rc("axes", prop_cycle=plot_style.cycler)
 result_datafile1 = results_folder.joinpath("dataset1.nc")
 result_datafile2 = results_folder.joinpath("dataset2.nc")
 result_datafile3 = results_folder.joinpath("dataset3.nc")
-fig1 = plot_overview(result_datafile1, linlog=True, linthresh=1)
+fig1, _ = plot_overview(result_datafile1, linlog=True, linthresh=1, figure_only=False)
 fig1.savefig(
     results_folder.joinpath("plot_overview_sim3d_d1.pdf"),
     bbox_inches="tight",
 )
 
-fig2 = plot_overview(result_datafile2, linlog=True, linthresh=1)
+fig2, _ = plot_overview(result_datafile2, linlog=True, linthresh=1, figure_only=False)
 fig2.savefig(
     results_folder.joinpath("plot_overview_sim3d_d2.pdf"),
     bbox_inches="tight",
 )
 
-fig3 = plot_overview(result_datafile3, linlog=True, linthresh=1)
+fig3, _ = plot_overview(result_datafile3, linlog=True, linthresh=1, figure_only=False)
 fig3.savefig(
     results_folder.joinpath("plot_overview_sim3d_d3.pdf"),
     bbox_inches="tight",

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_weight/sim_analysis_script_3d_weight.py
@@ -1,11 +1,11 @@
 # %%
 # Needed for plotting only
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/test/simultaneous_analysis_6d_disp/model.yml
+++ b/pyglotaran_examples/test/simultaneous_analysis_6d_disp/model.yml
@@ -1,4 +1,8 @@
-type: kinetic-spectrum
+default_megacomplex: decay
+
+dataset_groups:
+  default:
+    residual_function: non_negative_least_squares
 
 dataset:
   dataset1:
@@ -34,7 +38,7 @@ dataset:
 
 megacomplex:
   complex1:
-      k_matrix: [km1]
+    k_matrix: [km1]
 
 k_matrix:
   km1:
@@ -44,39 +48,39 @@ k_matrix:
       (s3, s3): rates.k3
 
 initial_concentration:
-    input1:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.2,inputs.3]
-    input2:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.7,inputs.8]
-    input3:
-      compartments: [s1,s2,s3]
-      parameters: [inputs.1,inputs.9,inputs.10]
+  input1:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.2, inputs.3]
+  input2:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.7, inputs.8]
+  input3:
+    compartments: [s1, s2, s3]
+    parameters: [inputs.1, inputs.9, inputs.10]
 #      exclude_from_normalize: [s1, s2, s3]
 
 irf:
   irf1_with_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center1]
-    width : [irf.width]
-    dispersion_center : irf.dispc
-    center_dispersion : [irf.disp1,irf.disp2]
+    type: spectral-multi-gaussian
+    center: [irf.center1]
+    width: [irf.width]
+    dispersion_center: irf.dispc
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
   irf2_with_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center2]
-    width : [irf.width]
-    dispersion_center : irf.dispc
-    center_dispersion : [irf.disp1,irf.disp2]
+    type: spectral-multi-gaussian
+    center: [irf.center2]
+    width: [irf.width]
+    dispersion_center: irf.dispc
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
   irf3_with_dispersion:
-    type : spectral-multi-gaussian
-    center : [irf.center3]
-    width : [irf.width]
-    dispersion_center : irf.dispc
-    center_dispersion : [irf.disp1,irf.disp2]
+    type: spectral-multi-gaussian
+    center: [irf.center3]
+    width: [irf.width]
+    dispersion_center: irf.dispc
+    center_dispersion_coefficients: [irf.disp1, irf.disp2]
 
-    # It works without equal_area_penalties but then the inputs cannot be estimated
-equal_area_penalties:
+    # It works without clp_area_penalties but then the inputs cannot be estimated
+clp_area_penalties:
   - type: equal_area
     source: s1
     source_intervals: [[300, 3000]]

--- a/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
@@ -1,11 +1,11 @@
 # %%
 # Needed for plotting only
 import matplotlib.pyplot as plt  # 3.3 or higher
-from glotaran.analysis.optimize import optimize
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
+from glotaran.optimization.optimize import optimize
 from glotaran.project.scheme import Scheme
 from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview

--- a/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
@@ -59,7 +59,7 @@ result = optimize(scheme)
 # evt opslaan
 
 
-save_result(result, results_folder, format_name="legacy", allow_overwrite=True)
+save_result(result, results_folder / "result.yml", allow_overwrite=True)
 # evt plotten
 # %% Set subsequent plots to the glotaran style
 plot_style = PlotStyle()

--- a/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
+++ b/pyglotaran_examples/test/simultaneous_analysis_6d_disp/sim_analysis_script_6d_disp.py
@@ -7,7 +7,7 @@ from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import save_result
 from glotaran.project.scheme import Scheme
-from pyglotaran_extras.io.boilerplate import setup_case_study
+from pyglotaran_extras.io import setup_case_study
 from pyglotaran_extras.plotting.plot_overview import plot_overview
 from pyglotaran_extras.plotting.style import PlotStyle
 
@@ -51,7 +51,6 @@ scheme = Scheme(
         "dataset6": dataset6,
     },
     maximum_number_function_evaluations=9,  # TRF needs 8m LM needs 127
-    non_negative_least_squares=True,
     # optimization_method="Levenberg-Marquardt", #LM needs nfev=127
 )
 # optimize
@@ -74,34 +73,34 @@ result_datafile3 = results_folder.joinpath("dataset3.nc")
 result_datafile4 = results_folder.joinpath("dataset4.nc")
 result_datafile5 = results_folder.joinpath("dataset5.nc")
 result_datafile6 = results_folder.joinpath("dataset6.nc")
-fig1 = plot_overview(result_datafile1, linlog=True, linthresh=5)
+fig1, _ = plot_overview(result_datafile1, linlog=True, linthresh=5, figure_only=False)
 fig1.savefig(
     results_folder.joinpath("plot_overview_dummy1.pdf"),
     bbox_inches="tight",
 )
 
-fig2 = plot_overview(result_datafile2, linlog=True, linthresh=5)
+fig2, _ = plot_overview(result_datafile2, linlog=True, linthresh=5, figure_only=False)
 fig2.savefig(
     results_folder.joinpath("plot_overview_dummy2.pdf"),
     bbox_inches="tight",
 )
 
-fig3 = plot_overview(result_datafile3, linlog=True, linthresh=5)
+fig3, _ = plot_overview(result_datafile3, linlog=True, linthresh=5, figure_only=False)
 fig3.savefig(
     results_folder.joinpath("plot_overview_dummy3.pdf"),
     bbox_inches="tight",
 )
-fig4 = plot_overview(result_datafile4, linlog=True, linthresh=5)
+fig4, _ = plot_overview(result_datafile4, linlog=True, linthresh=5, figure_only=False)
 fig4.savefig(
     results_folder.joinpath("plot_overview_dummy4.pdf"),
     bbox_inches="tight",
 )
-fig5 = plot_overview(result_datafile5, linlog=True, linthresh=5)
+fig5, _ = plot_overview(result_datafile5, linlog=True, linthresh=5, figure_only=False)
 fig5.savefig(
     results_folder.joinpath("plot_overview_dummy5.pdf"),
     bbox_inches="tight",
 )
-fig6 = plot_overview(result_datafile6, linlog=True, linthresh=5)
+fig6, _ = plot_overview(result_datafile6, linlog=True, linthresh=5, figure_only=False)
 fig6.savefig(
     results_folder.joinpath("plot_overview_dummy6.pdf"),
     bbox_inches="tight",

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -8,6 +8,9 @@ import warnings
 from pathlib import Path
 
 import yaargh
+from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
+from glotaran.io import save_result
+from matplotlib.backends.backend_pdf import PdfPages
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -67,13 +70,9 @@ def script_run_wrapper(func):
                 "ignore", message=r"Matplotlib.+non-GUI.+", category=UserWarning
             )
             if kwargs["raise_on_deprecation"]:
-                warnings.filterwarnings(
-                    "error", message=r".+glotaran.+", category=DeprecationWarning
-                )
+                warnings.filterwarnings("error", category=GlotaranApiDeprecationWarning)
             else:
-                warnings.filterwarnings(
-                    "always", message=r".+glotaran.+", category=DeprecationWarning
-                )
+                warnings.filterwarnings("always", category=GlotaranApiDeprecationWarning)
             if "GITHUB" in os.environ:
                 warnings.formatwarning = github_format_warning
 

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -11,6 +11,7 @@ import yaargh
 from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
 from glotaran.io import save_result
 from matplotlib.backends.backend_pdf import PdfPages
+from pyglotaran_extras.deprecation.deprecation_utils import PyglotaranExtrasApiDeprecationWarning
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -71,8 +72,10 @@ def script_run_wrapper(func):
             )
             if kwargs["raise_on_deprecation"]:
                 warnings.filterwarnings("error", category=GlotaranApiDeprecationWarning)
+                warnings.filterwarnings("error", category=PyglotaranExtrasApiDeprecationWarning)
             else:
                 warnings.filterwarnings("always", category=GlotaranApiDeprecationWarning)
+                warnings.filterwarnings("always", category=PyglotaranExtrasApiDeprecationWarning)
             if "GITHUB" in os.environ:
                 warnings.formatwarning = github_format_warning
 

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -8,10 +8,6 @@ import warnings
 from pathlib import Path
 
 import yaargh
-from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
-from glotaran.io import save_result
-from matplotlib.backends.backend_pdf import PdfPages
-from pyglotaran_extras.deprecation.deprecation_utils import PyglotaranExtrasApiDeprecationWarning
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -60,6 +56,11 @@ def compress_all_results():
 def script_run_wrapper(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
+        from pyglotaran_extras.deprecation.deprecation_utils import (
+            PyglotaranExtrasApiDeprecationWarning,
+        )
+
         print("\n", "#" * 80, sep="")
         print("#", f"RUNNING: {func.__name__.upper()}".center(78), "#", sep="")
         print("#" * 80, "\n")

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -139,9 +139,7 @@ def spectral_guidance(*, headless=False, raise_on_deprecation=False):
     from pyglotaran_examples.ex_spectral_guidance import ex_spectral_guidance
 
     result = ex_spectral_guidance.main()
-    save_result(
-        result, ex_spectral_guidance.results_folder, format_name="legacy", allow_overwrite=True
-    )
+    save_result(result, ex_spectral_guidance.results_folder / "result.yml", allow_overwrite=True)
     ex_spectral_guidance.load_and_plot_results()
 
 


### PR DESCRIPTION
This upgrades the model files to use the pyglotaran `0.5.0` syntax and the script files to use the pyglotaran-extras `0.5.0rc1` syntax.

Best reviewed commit by commit.

All deprecations up to the [current main of pyglotaran](https://github.com/glotaran/pyglotaran/commit/69bb7dc066539c21192465a8df5d5b6df5c01fc1) were removed.