### PR TITLE
👌🚇 Write all result files with zlib compression activated

### DIFF
--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -5,7 +5,6 @@ import sys
 import warnings
 from pathlib import Path
 
-import xarray as xr
 import yaargh
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -35,7 +34,9 @@ def save_all_figures(filename: str):
 
 
 def compress_nc_file(file_path: str | Path):
-    """Rewrite *.nc files with activated compression.."""
+    """Rewrite *.nc files with activated compression."""
+    import xarray as xr
+
     ds = xr.load_dataset(file_path)
     comp = {"zlib": True, "complevel": 5}
     encoding = {var: comp for var in ds.data_vars}

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -5,6 +5,7 @@ import sys
 import warnings
 from pathlib import Path
 
+import xarray as xr
 import yaargh
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -33,6 +34,22 @@ def save_all_figures(filename: str):
     print(f"Saved plotting result to: {result_file}")
 
 
+def compress_nc_file(file_path: str | Path):
+    """Rewrite *.nc files with activated compression.."""
+    ds = xr.load_dataset(file_path)
+    comp = {"zlib": True, "complevel": 5}
+    encoding = {var: comp for var in ds.data_vars}
+    ds.to_netcdf(file_path, encoding=encoding)
+
+
+def compress_all_results():
+    """Rewrite all *.nc result files with activated compression."""
+    results_path = Path.home() / "pyglotaran_examples_results"
+
+    for data_file in results_path.rglob("*.nc"):
+        compress_nc_file(data_file)
+
+
 def script_run_wrapper(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -58,6 +75,7 @@ def script_run_wrapper(func):
                 warnings.formatwarning = github_format_warning
 
         func(*args, **kwargs)
+        compress_all_results()
 
         if kwargs["headless"]:
             save_all_figures(f"{func.__name__}.pdf")

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import json
 import os


### PR DESCRIPTION
This is a hotfix to allow us to update the "gold standard" which [currently fails for DOAS due to too big files (over 100MB)](https://github.com/glotaran/pyglotaran-examples/runs/5711532975?check_suite_focus=true).
This reduces file since to ~2/3 (at least for the DOAS `104MB` -> `64MB`).

Later we should add this as a proper argument for `save_result` and the netCDF plugin in `pyglotaran` itself.

### Change summary

- [👌🚇 Write all result files with zlib compression activated](https://github.com/glotaran/pyglotaran-examples/commit/5b5c8656e4f45b9cd8877ef1a24134e26d3b77b7)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)