### PR TITLE
♻️ Raised maximum_number_function_evaluations of ex_two_datasets from 15 to 18

### DIFF
--- a/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
+++ b/pyglotaran_examples/ex_two_datasets/ex_two_datasets.py
@@ -38,7 +38,7 @@ scheme = Scheme(
     model,
     parameters,
     {"dataset1": dataset1, "dataset2": dataset2},
-    maximum_number_function_evaluations=15,
+    maximum_number_function_evaluations=18,
     non_negative_least_squares=True,
     optimization_method="TrustRegionReflection",
 )


### PR DESCRIPTION
This is needed for https://github.com/glotaran/pyglotaran/pull/1060 to pass the result comparison with `ex_two_datasets` which now needs more function evaluation to fully converge.
The reason for the additionally needed function evaluation will be investigated later


### Change summary

- [♻️ Raised maximum_number_function_evaluations of ex_two_datasets from 15 to 18](https://github.com/glotaran/pyglotaran-examples/commit/b6657f2d492ebd41b7cc5362d5641822949787d5)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
