### PR TITLE
👌 Change 'spectral-multi-gaussian' to 'gaussian' if no dispersion is used

### DIFF
--- a/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/model.yml
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_nodisp/model.yml
@@ -46,9 +46,9 @@ initial_concentration:
 
 irf:
   irf1_no_dispersion:
-    type: spectral-multi-gaussian
-    center: [irf.center]
-    width: [irf.width]
+    type: gaussian
+    center: irf.center
+    width: irf.width
 
     # It works without clp_area_penalties but then the inputs cannot be estimated
 clp_area_penalties:

--- a/pyglotaran_examples/test/simultaneous_analysis_3d_weight/model.yml
+++ b/pyglotaran_examples/test/simultaneous_analysis_3d_weight/model.yml
@@ -45,17 +45,17 @@ initial_concentration:
 
 irf:
   irf1_no_dispersion:
-    type: spectral-multi-gaussian
-    center: [irf.center1]
-    width: [irf.width1]
+    type: gaussian
+    center: irf.center1
+    width: irf.width1
   irf2_no_dispersion:
-    type: spectral-multi-gaussian
-    center: [irf.center2]
-    width: [irf.width1]
+    type: gaussian
+    center: irf.center2
+    width: irf.width1
   irf3_no_dispersion:
-    type: spectral-multi-gaussian
-    center: [irf.center3]
-    width: [irf.width2]
+    type: gaussian
+    center: irf.center3
+    width: irf.width2
 
 clp_area_penalties:
   - type: equal_area


### PR DESCRIPTION
This removes the improper usage of `spectral-multi-gaussian` IRF without dispersion and changes it to a `gaussian` IRF.

The validation in https://github.com/glotaran/pyglotaran/pull/1135 is a lot stricter and prohibits wrong usage (model crash).

### Change summary

- [🩹 Changed 'spectral-multi-gaussian' to 'gaussian' if no dispersion is used](https://github.com/glotaran/pyglotaran-examples/commit/a61448fbbbff4cf8f91a85a24e0a13515ca65a0a)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)