### PR TITLE
♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
         if [ '${{ inputs.set_example_list }}' = 'false' ]
         then
           python pyglotaran-examples/scripts/run_examples.py ${{ inputs.example_name }} --headless 2>&1
-          echo "::set-output name=plots-path::pyglotaran-examples/plot_results"
+          echo "plots-path=pyglotaran-examples/plot_results"  >> $GITHUB_OUTPUT
         else
           pip install yaargh
           python pyglotaran-examples/scripts/run_examples.py set-gha-example-list-output

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -218,7 +218,9 @@ def run_all(*, headless=False, raise_on_deprecation=False):
 def set_gha_example_list_output():
     """Export a list of all examples to an output github in github actions."""
     example_names = [func.__name__.replace("_", "-") for func in all_funcs]
-    print(f"::set-output name=example-list::{json.dumps(example_names)}")
+    gh_output = Path(os.getenv("GITHUB_OUTPUT", ""))
+    with gh_output.open("a", encoding="utf8") as f:
+        f.writelines([f"example-list={json.dumps(example_names)}"])
 
 
 parser = yaargh.ArghParser()


### PR DESCRIPTION
GitHub deprecated the usage of `set-output` in favor of using the environment file located at `$GITHUB_OUTPUT`.
The old syntax already gives warnings and will be switched off 31st May 2023.
This change makes the CI more future proof.

Ref.: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


### Change summary

- [♻️ Upgraded github action output setting](https://github.com/glotaran/pyglotaran-examples/commit/b3f67d050a65d9c73e4f0f2aa603fb9323bb57e0)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)