### PR TITLE
🚇 Upload comparison-results as asset on release

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,6 +2,8 @@ name: "Run Examples"
 
 on:
   push:
+    tags:
+      - v**
   pull_request:
   workflow_dispatch:
     inputs:
@@ -114,3 +116,20 @@ jobs:
         uses: glotaran/pyglotaran-validation@main
         with:
           validation_name: pyglotaran-examples
+
+      - name: Get tag
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        id: tag
+        uses: devops-actions/action-get-tag@v1.0.1
+
+      - name: 📦 Create release asset
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        run: cd comparison-results && zip -r ../comparison-results-${{steps.tag.outputs.tag}}.zip . -x .git
+
+      - name: 🚀⬆️ Upload Release Asset
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: comparison-results-${{steps.tag.outputs.tag}}.zip
+          generate_release_notes: true
+          append_body: true

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -133,3 +133,11 @@ jobs:
           files: comparison-results-${{steps.tag.outputs.tag}}.zip
           generate_release_notes: true
           append_body: true
+
+      - name: 📦 Create comparison-results tag
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: comparison-results
+          custom_tag: comparison-results-${{steps.tag.outputs.tag}}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -144,9 +144,10 @@ jobs:
           append_body: true
 
       - name: 📦 Create comparison-results tag
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: comparison-results
-          custom_tag: comparison-results-${{steps.tag.outputs.tag}}
-          tag_prefix: ""
+        run: |
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          NEW_VERSION="comparison-results-${{steps.tag.outputs.tag}}"
+          git tag -a $NEW_VERSION -m "Comparison results used with release ${{steps.tag.outputs.tag}}"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git push origin $NEW_VERSION

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -134,7 +134,7 @@ jobs:
         uses: devops-actions/action-get-tag@v1.0.1
 
       - name: 📦 Create release asset
-        run: zip -r comparison-results-${{steps.tag.outputs.tag}}.zip . -x .git
+        run: zip -r comparison-results-${{steps.tag.outputs.tag}}.zip . -x ".git/*"
 
       - name: 🚀⬆️ Upload Release Asset
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -117,17 +117,26 @@ jobs:
         with:
           validation_name: pyglotaran-examples
 
-      - name: Get tag
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+  create-release:
+    name: "🚀 Create release assets and tag comparison-results branch"
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    needs: [compare-results]
+    steps:
+      - name: ⏬ Checkout compare results
+        uses: actions/checkout@v3
+        with:
+          repository: "glotaran/pyglotaran-examples"
+          ref: comparison-results
+
+      - name: Get tag name
         id: tag
         uses: devops-actions/action-get-tag@v1.0.1
 
       - name: 📦 Create release asset
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        run: cd comparison-results && zip -r ../comparison-results-${{steps.tag.outputs.tag}}.zip . -x .git
+        run: zip -r comparison-results-${{steps.tag.outputs.tag}}.zip . -x .git
 
       - name: 🚀⬆️ Upload Release Asset
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1
         with:
           files: comparison-results-${{steps.tag.outputs.tag}}.zip
@@ -135,9 +144,9 @@ jobs:
           append_body: true
 
       - name: 📦 Create comparison-results tag
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: comparison-results
           custom_tag: comparison-results-${{steps.tag.outputs.tag}}
+          tag_prefix: ""

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Get tag name
         id: tag
-        uses: devops-actions/action-get-tag@v1.0.1
+        uses: devops-actions/action-get-tag@v1.0.2
 
       - name: 📦 Create release asset
         run: zip -r comparison-results-${{steps.tag.outputs.tag}}.zip . -x ".git/*"


### PR DESCRIPTION
This change adds steps to the CI that upload the `comparison-results` as release artifact on a release.
[See my fork for an example release](https://github.com/s-weigand/pyglotaran-examples/releases/tag/v-asset-upload-test)

### Change summary

- [🚇🚀 Add steps to upload release assets](https://github.com/glotaran/pyglotaran-examples/commit/c18959cb6a99656cc57eb3e22d222956ce34ce3b)
- [🚇🚀 Tag comparison-results branch on release](https://github.com/glotaran/pyglotaran-examples/commit/0d7cbc8a171b2a198d4942414f4e726ee3e2de47)
- [👌🚇 Factor out release steps into seperate job](https://github.com/glotaran/pyglotaran-examples/commit/08c2d4e4ca2d44d55280f7c3938b1239367771e6)
- [👌 Exclude .git folder](https://github.com/glotaran/pyglotaran-examples/commit/1bcabaaf961c5c4dc8505623764b541869412259)
- [🩹 Manually create and push tag](https://github.com/glotaran/pyglotaran-examples/commit/d3eb766a5ae6fd1a14fa51d69ce00c93eac12aa1)
- [🚇⬆️ Update devops-actions/action-get-tag GHA](https://github.com/glotaran/pyglotaran-examples/commit/2eb37d63c6e0989023bd510473a8538cbe5c5870)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)