### PR TITLE
🚧🩹 Suffix ex_doas_beta CA clp_labels with megcomplex name (_artifact)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: skip
+        name: skip
+        entry: skip
+        language: fail
+        files: '^$'


### PR DESCRIPTION
To be compatible with the [bugfix of coherent artifacts using the same clp_labels for all megacomplexes](https://github.com/glotaran/pyglotaran/pull/1292) we need to change the (data used in) comparison results.
Specifically, the (labels in) dataset ex_doas_beta/target_analysis/dataset1.nc need updating.

I used the following code to update the cpl_labels for the coherent artifact in the ex_doas_beta case study.

```py
from glotaran.io import load_dataset, save_dataset

data_path = "ex_doas_beta/target_analysis/dataset1.nc"

data = load_dataset(data_path)

new_clps = []

for val in data.coords["clp_label"].values:
    if val.startswith("coherent_artifact"):
        val = f'{val}_artifact'
    new_clps.append(val)
new_clps

new_data = data.assign_coords(clp_label=new_clps)

save_dataset(new_data, data_path, allow_overwrite=True)
```

### Change summary

- [🩹 Suffix ex_doas_beta CA clp_labels with megcomplex name (_artifact)](https://github.com/glotaran/pyglotaran-examples/commit/6a9afad55044bbd9ebddedc193d3c4e585b00784)
