### PR TITLE
👌 Use clp-guide megacomplex instead of the 1x1 k-matrix workaround

### DIFF
--- a/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
+++ b/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
@@ -21,7 +21,9 @@ megacomplex:
   complex1:
     k_matrix: [km1]
   complex2:
-    k_matrix: [km2]
+    type: clp-guide
+    dimension: time
+    target: s5
 
 k_matrix:
   km1:
@@ -32,9 +34,6 @@ k_matrix:
       (s5, s2): rates.k4
       (s6, s3): rates.k5
       (s6, s6): rates.k6
-      (s5, s5): rates.k6
-  km2:
-    matrix:
       (s5, s5): rates.k6
 
 initial_concentration:

--- a/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
+++ b/pyglotaran_examples/ex_spectral_guidance/models/model_guidance.yml
@@ -13,8 +13,6 @@ dataset:
     scale: scale.1
   dataset2:
     megacomplex: [complex2]
-    initial_concentration: input2
-    #    irf: None
     scale: scale.2
 
 megacomplex:
@@ -41,9 +39,6 @@ initial_concentration:
     compartments: [s1, s2, s3, s4, s5, s6]
     parameters:
       [inputs.s1, inputs.s1, inputs.s1, inputs.s2, inputs.s1, inputs.s1]
-  input2:
-    compartments: [s5]
-    parameters: [inputs.s2]
 
 clp_area_penalties:
   - type: equal_area


### PR DESCRIPTION
This change updates the syntax of the spectral guide example to use a `clp-guide` megacomplex instead of the initial workaround of a to use a decay megacomplex where the k-matrix only has a single compartment that decays to the ground state.

### Change summary

- [👌 Use clp-guide megacomplex instead of the 1x1 k-matrix workaround](https://github.com/glotaran/pyglotaran-examples/commit/ace595ef2bab7ddff961cf81ecc3722ee863805d)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
